### PR TITLE
prevent wrapping of buttons and header on mobile

### DIFF
--- a/css/firstrunwizard.css
+++ b/css/firstrunwizard.css
@@ -5,6 +5,7 @@
 
 #firstrunwizard h1 {
 	font-size: 40px;
+	line-height: 130%;
 	margin: 50px 0 20px;
 }
 


### PR DESCRIPTION
Previously the buttons in the modal were weirdly wrapping on mobile, this is now fixed.

Same goes for the heading »Welcome to ownCloud«.

Please review @owncloud/designers @karlitschek 
