### PR TITLE
use light font weight for headings, like in core

### DIFF
--- a/css/firstrunwizard.css
+++ b/css/firstrunwizard.css
@@ -5,12 +5,14 @@
 
 #firstrunwizard h1 {
 	font-size: 40px;
+	font-weight: 300;
 	line-height: 130%;
 	margin: 50px 0 20px;
 }
 
 #firstrunwizard h2 {
 	font-size: 20px;
+	font-weight: 300;
 	margin: 35px 0 10px;
 }
 


### PR DESCRIPTION
Please review @karlitschek @owncloud/designers, wasn’t consistent before so I would like to backport this.