### PR TITLE
Add minimum and maximum required versions

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,7 +7,9 @@ The First Run Wizard can be customized to meet specific design goals, or to chan
 </description>
 	<licence>AGPL</licence>
 	<author>Frank Karlitschek, Jan-Christoph Borchardt</author>
-	<require>4.9</require>
+	<dependencies>
+		<owncloud min-version="9.0" max-version="9.0" />
+	</dependencies>
 	<shipped>true</shipped>
 	<default_enable/>
 	<ocsid>166055</ocsid>


### PR DESCRIPTION
Fixes "This app has no minimum ownCloud version assigned. This will be an error in ownCloud 11 and later."

![2016-02-05_14-53-04](https://cloud.githubusercontent.com/assets/878997/12848123/2c4cf836-cc18-11e5-9055-0c33e6817ecc.png)
