### PR TITLE
Only display wizard popup in files app

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -26,13 +26,20 @@ use OCP\Util;
 Util::addStyle('firstrunwizard', 'colorbox');
 Util::addScript('firstrunwizard', 'jquery.colorbox');
 Util::addScript('firstrunwizard', 'firstrunwizard');
-
 Util::addStyle('firstrunwizard', 'firstrunwizard');
 
-$config = \OC::$server->getConfig();
-$userSession = \OC::$server->getUserSession();
-$firstRunConfig = new Config($config, $userSession);
+// only load when the file app displays
+$eventDispatcher = \OC::$server->getEventDispatcher();
+$eventDispatcher->addListener(
+	'OCA\Files::loadAdditionalScripts',
+	function() {
+		$config = \OC::$server->getConfig();
+		$userSession = \OC::$server->getUserSession();
+		$firstRunConfig = new Config($config, $userSession);
 
-if ($userSession->isLoggedIn() && $firstRunConfig->isEnabled()) {
-	Util::addScript( 'firstrunwizard', 'activate');
-}
+		if ($userSession->isLoggedIn() && $firstRunConfig->isEnabled()) {
+			Util::addScript( 'firstrunwizard', 'activate');
+		}
+	}
+);
+


### PR DESCRIPTION
Prevents the popup to appear in other pages like in the two factor
validation one.

Fixes https://github.com/owncloud/core/issues/26137#issuecomment-248135211

Please review @DeepDiver1975 @butonic @cornelinux

Backport to stable9.1 required to fix the two factor situation