### PR TITLE
Remove obsolete ref to SVGSupport

### DIFF
--- a/js/firstrunwizard.js
+++ b/js/firstrunwizard.js
@@ -6,11 +6,6 @@ function showfirstrunwizard(){
 		width:"70%", 
 		height:"70%", 
 		href: OC.filePath('firstrunwizard', '', 'wizard.php'),
-		onComplete : function(){
-			if (!SVGSupport()) {
-				replaceSVG();
-			}
-		},
 		onClosed : function(){
 			$.ajax({
 			url: OC.filePath('firstrunwizard', 'ajax', 'disable.php'),


### PR DESCRIPTION
SVG is now always supported, the API for the check was removed in 9.1

This PR simply prevents a JS error message in the console, nothing more.

@DeepDiver1975 @butonic 