### PR TITLE
Updating getEdition() to use core method

### DIFF
--- a/lib/util.php
+++ b/lib/util.php
@@ -46,14 +46,12 @@ class Util {
 	}
 
 	/**
-	 * mimic \OC_Util::getEditionString()
+	 * \OC_Util::getEditionString() from global namespace 
+	 * (core:lib/private/legacy/util.php)
 	 * @return string
 	 */
 	public function getEdition() {
-		if ($this->appManager->isEnabledForUser('enterprise_key')) {
-			return 'Enterprise';
-		}
-		return '';
+		return \OC_Util::getEditionString();
 	}
 
 	/**

--- a/tests/lib/utiltest.php
+++ b/tests/lib/utiltest.php
@@ -7,31 +7,13 @@ use OCA\FirstRunWizard\Util;
 class UtilTest extends \PHPUnit_Framework_TestCase {
 
 	/**
-	 * @dataProvider getEditionData
+	 * same code as in core: tests/lib/UtilTest.php
 	 */
-	public function testGetEdition($isEnterpriseKeyEnabled, $string) {
-		$appManager = $this->getMockBuilder('\OCP\App\IAppManager')
-			->disableOriginalConstructor()->getMock();
-		$config = $this->getMockBuilder('\OCP\IConfig')
-			->disableOriginalConstructor()->getMock();
-		$defaults = $this->getMockBuilder('\OCP\Defaults')
-			->disableOriginalConstructor()->getMock();
-
-		$appManager->expects($this->once())
-			->method('isEnabledForUser')
-			->with('enterprise_key')
-			->will($this->returnValue($isEnterpriseKeyEnabled));
-
-		$util = new Util($appManager, $config, $defaults);
-		$this->assertEquals($string, $util->getEdition());
+	public function testGetEditionString() {
+		$edition = \OC_Util::getEditionString();
+		$this->assertTrue(is_string($edition));
 	}
 
-	public function getEditionData() {
-		return [
-			[true, 'Enterprise'],
-			[false, ''],
-		];
-	}
 
 	/**
 	 * @dataProvider getSyncClientUrlsData


### PR DESCRIPTION
@PVince81 
Referencing https://github.com/owncloud/core/pull/27214#issuecomment-282698417

With this PR, firstrunwizard eliminates code duplication and uses the method provided in core.

The core function is found in file
``lib/private/legacy/util.php``
``public static function getEditionString()``

Testmethod:
- cloning and preperation setup steps for core
- cloning firstrunwizard and incorporate changes
- finalize owncloud setup
- firstrunmessage appears as expected :white_check_mark:
