### PR TITLE
Run drone on stable10

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,7 @@ workspace:
   base: /var/www/owncloud
   path: apps/firstrunwizard
 
-branches: [master, release*, release/*]
+branches: [master, release*, release/*, stable10]
 
 pipeline:
   install-core:


### PR DESCRIPTION
Forward port from `stable10` PR #91 of change to `.drone.yml` to keep them the same.