### PR TITLE
Adjust composer files and app core min-version for 'drop PHP 5.6'

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@ The First run wizard can be customized to meet specific design goals, or to chan
 	<licence>AGPL</licence>
 	<author>Frank Karlitschek, Jan-Christoph Borchardt</author>
 	<dependencies>
-		<owncloud min-version="10" max-version="11" />
+		<owncloud min-version="10.2" max-version="11" />
 	</dependencies>
 	<version>1.1.1</version>
 	<namespace>FirstRunWizard</namespace>

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "owncloud/firstrunwizard",
   "config" : {
     "platform": {
-      "php": "5.6.37"
+      "php": "7.0.8"
     }
   },
   "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "41ca90ec5e3e06e691ff177b6852cee7",
+    "content-hash": "0b53c9e5d38ed856b8838d76abdbe034",
     "packages": [],
     "packages-dev": [
         {
@@ -55,6 +55,6 @@
     "platform": [],
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6.37"
+        "php": "7.0.8"
     }
 }


### PR DESCRIPTION
- [x] adjust local `composer` files to PHP 7.0.8
- [x] bump app core min-version to `10.2`

because the app is now being tested only against core `stable10` upcoming `10.2` that has dropped PHP 5.6 support.
