### PR TITLE
Add sabre/xml to behat dependencies

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -1214,10 +1214,7 @@ def installTestrunner(phpVersion, useBundledApp):
 			'rsync -aIX /tmp/testrunner /var/www/owncloud',
 		] + ([
 			'cp -r /var/www/owncloud/testrunner/apps/%s /var/www/owncloud/server/apps/' % config['app']
-		] if not useBundledApp else []) + [
-			'cd /var/www/owncloud/testrunner',
-			'make install-composer-deps'
-		]
+		] if not useBundledApp else [])
 	}]
 
 def installExtraApps(phpVersion, extraApps):

--- a/.drone.yml
+++ b/.drone.yml
@@ -318,8 +318,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/firstrunwizard /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-firstrunwizard
   pull: always
@@ -436,8 +434,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/firstrunwizard /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-firstrunwizard
   pull: always
@@ -555,8 +551,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/firstrunwizard /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-firstrunwizard
   pull: always
@@ -673,8 +667,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/firstrunwizard /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-firstrunwizard
   pull: always

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -13,6 +13,7 @@
         "rdx/behat-variables": "^1.2",
         "sensiolabs/behat-page-object-extension": "^2.0",
         "symfony/translation": "^3.4",
+        "sabre/xml": "^2.1",
         "guzzlehttp/guzzle": "^5.3",
         "phpunit/phpunit": "^7.5"
     }


### PR DESCRIPTION
It is needed by core `HttpRequestHelper.php` `parseResponseAsXml`

And there is no longer any need to `make install-composer-deps` in the testrunner core folder, because those dependencies are not used by behat any more.