### PR TITLE
[tests-only]Replace excludes_analyse with excludePaths in phpstan.neon

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ parameters:
   inferPrivatePropertyTypeFromConstructor: true
   bootstrapFiles:
     - %currentWorkingDirectory%/../../lib/base.php
-  excludes_analyse:
+  excludePaths:
     - %currentWorkingDirectory%/appinfo/routes.php
   ignoreErrors:
 


### PR DESCRIPTION
## Description
```
php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan analyse --memory-limit=4G --configuration=./phpstan.neon --no-progress --level=5 appinfo lib
⚠️  You're using a deprecated config option excludes_analyse. ⚠️️

Parameter excludes_analyse has been deprecated so use excludePaths only from now on.

                                                                                                                        
 [OK] No errors                                                                                    
```

Adjust `phpstan.neon` to use the new `excludePaths` to avoid this warning.
## Related Issue
- Part of issue: https://github.com/owncloud/QA/issues/745