### PR TITLE
Always return an int from Symfony Command execute method

### DIFF
--- a/lib/Command/ResetAll.php
+++ b/lib/Command/ResetAll.php
@@ -65,9 +65,9 @@ class ResetAll extends Command {
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
 	 *
-	 * @return int|null|void
+	 * @return int
 	 */
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		$output->writeln('Resetting firstrunwizard for all users');
 		$progress = new ProgressBar($output);
 		$this->config->resetAllUsers(function ($user) use ($progress) {
@@ -76,5 +76,6 @@ class ResetAll extends Command {
 		$progress->finish();
 		$output->writeln("");
 		$output->writeln("<info>Done</info>");
+		return 0;
 	}
 }


### PR DESCRIPTION
Symfony 5 will require this, so be prepared.
For Symfony 4 it is optional.

Preparation for https://github.com/owncloud/core/issues/39630