### PR TITLE
feat: add dist build workflow

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -9,7 +9,8 @@ on:
       - synchronize
       - reopened
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,0 +1,16 @@
+name: Build dist
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions: {}
+
+jobs:
+  build:
+    uses: owncloud/reusable-workflows/.github/workflows/build.yml@main

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ appstore:
 	wizard.php \
 	$(appstore_package_name)
 
-	rm -R $(appstore_package_name)/l10n/{.tx,.gitignore}
+	rm -Rf $(appstore_package_name)/l10n/.tx $(appstore_package_name)/l10n/.gitignore
 ifdef CAN_SIGN
 	$(sign) --path="$(appstore_package_name)"
 else


### PR DESCRIPTION
Adopts the reusable `build` workflow from [owncloud/reusable-workflows](https://github.com/owncloud/reusable-workflows) to run `make dist` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)