### PR TITLE
chore: bump version to 1.4.0 for ownCloud 11.0.0-rc1

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@ The First run wizard can be customized to meet specific design goals, or to chan
 	<dependencies>
 		<owncloud min-version="11" max-version="11" />
 	</dependencies>
-	<version>1.3.0</version>
+	<version>1.4.0</version>
 	<namespace>FirstRunWizard</namespace>
 	<default_enable/>
 	<commands>


### PR DESCRIPTION
Bumps the app version to 1.4.0 so it can be released for the ownCloud 11.0.0-rc1 bundle (the existing v1.3.0 tag is the oc10 release). App is already oc11-compatible (`max-version="11"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)