### PR TITLE
ci: allow manual workflow_dispatch trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ on:
       - opened
       - synchronize
       - reopened
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Add a `workflow_dispatch` trigger to the CI workflow.

## Why

CI consumes `owncloud/reusable-workflows/.github/workflows/acceptance.yml@main`.
When a fix lands upstream in that reusable workflow, **re-running an existing
run does not pick it up** — GitHub pins the originally-resolved workflow at run
creation. Without `workflow_dispatch`, the only way to pull the updated workflow
is a fresh `push`/`pull_request`, which forces committing an unrelated change.

Adding `workflow_dispatch` lets us re-trigger CI on demand against the latest
`@main`.

## Note

Opening this PR also serves to validate reusable-workflows#74 (the fix that adds
`occ upgrade` after enabling the app under test, resolving the `needsDbUpgrade`
→ HTTP 503 failures in acceptance tests). This PR's own CI run is the first
firstrunwizard event to resolve `reusable-workflows@main` after that merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
