### PR TITLE
chore: bump version to 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+
+## [1.4.1] - 2026-07-22
+
+### Changed
+- Maintenance release re-signed with the ownCloud G2 code-signing certificate for the ownCloud 11.0.0 release.
+
+## [1.4.0] - 2026-06-29
+
+### Changed
+- ownCloud 11 compatible release (oc 11.0.0-rc1).
+
 ## [1.2.0] - 2019-04-16
 
 ### Added
@@ -44,6 +55,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
  - Initial implementation
 
-[Unreleased]: https://github.com/owncloud/firstrunwizard/compare/v1.2.0...master
+[Unreleased]: https://github.com/owncloud/firstrunwizard/compare/v1.4.1..master
+[1.4.1]: https://github.com/owncloud/firstrunwizard/compare/v1.4.0..v1.4.1
+[1.4.0]: https://github.com/owncloud/firstrunwizard/compare/v1.2.0..v1.4.0
 [1.2.0]: https://github.com/owncloud/firstrunwizard/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/owncloud/firstrunwizard/compare/v1.1...v1.1.1
+[1.1]: https://github.com/owncloud/firstrunwizard/compare/v1.0..v1.1

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@ The First run wizard can be customized to meet specific design goals, or to chan
 	<dependencies>
 		<owncloud min-version="11" max-version="11" />
 	</dependencies>
-	<version>1.4.0</version>
+	<version>1.4.1</version>
 	<namespace>FirstRunWizard</namespace>
 	<default_enable/>
 	<commands>


### PR DESCRIPTION
Patch-level version bump (1.4.0 -> 1.4.1) for the oc11 (11.0.0) complete release. Part of the G2 code-signing re-release.