### PR TITLE
refactor(routing): rewire the legacy routes to extension-free urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Rewire the legacy routes to extension-free urls so they are reachable at their own declared urls - [#203](https://github.com/owncloud/firstrunwizard/pull/203)
 
 ## [1.4.1] - 2026-07-22
 

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -8,9 +8,9 @@
 
 /** @var $this OC\Route\Router */
 
-$this->create('firstrunwizard_enable', 'ajax/enable.php')
+$this->create('firstrunwizard_enable', 'ajax/enable')
 	->actionInclude('firstrunwizard/ajax/enable.php');
-$this->create('firstrunwizard_disable', 'ajax/disable.php')
+$this->create('firstrunwizard_disable', 'ajax/disable')
 	->actionInclude('firstrunwizard/ajax/disable.php');
-$this->create('firstrunwizard_wizard', 'wizard.php')
+$this->create('firstrunwizard_wizard', 'wizard')
 	->actionInclude('firstrunwizard/wizard.php');

--- a/js/firstrunwizard.js
+++ b/js/firstrunwizard.js
@@ -5,10 +5,10 @@ function showfirstrunwizard(){
 		speed:100, 
 		width:"70%", 
 		height:"70%", 
-		href: OC.filePath('firstrunwizard', '', 'wizard.php'),
+		href: OC.generateUrl('/apps/firstrunwizard/wizard'),
 		onClosed : function(){
 			$.ajax({
-			url: OC.filePath('firstrunwizard', 'ajax', 'disable.php'),
+			url: OC.generateUrl('/apps/firstrunwizard/ajax/disable'),
 			data: ""
 			});
 		}  


### PR DESCRIPTION
## Description

Hardening, in the same class as owncloud/core#41740 and rewired the same way as
owncloud/core#41742. **No user-visible behaviour change** — see *Impact* below.

All three routes in `appinfo/routes.php` declared a url that is itself a real
file on disk. The router prefixes app route urls with `/apps/<appid>`, so
`ajax/enable.php` becomes `/apps/firstrunwizard/ajax/enable.php`, and the front
controller rewrite generated by `\OC\Setup::updateHtaccess()` skips paths that
exist:

```apache
RewriteCond %{REQUEST_FILENAME} !-f
RewriteRule . index.php [PT,E=PATH_INFO:$1]
```

The web server therefore executes those scripts directly, without the bootstrap
`index.php` would have performed, and such a request dies with
`Class "OCP\User" not found` → HTTP 500. The routes were unreachable at their
own declared urls.

| route | old url | new url |
| --- | --- | --- |
| `firstrunwizard_enable` | `ajax/enable.php` | `ajax/enable` |
| `firstrunwizard_disable` | `ajax/disable.php` | `ajax/disable` |
| `firstrunwizard_wizard` | `wizard.php` | `wizard` |

## Impact: latent, not a live bug

`OC.filePath()` unconditionally injects `/index.php/` for non-core app `.php`
files (`core/js/js.js`, the `file.substring(file.length - 3) === 'php' && !isCore`
branch), so the js callers always requested the routed
`/index.php/apps/firstrunwizard/...` form — which works. The wizard is not
broken today.

Measured on a pristine `owncloud/server:11.0.0-rc2` with an authenticated
session:

| url | before | after |
| --- | --- | --- |
| `/index.php/apps/firstrunwizard/wizard.php` (what the shipped js requests) | 200, 1585 bytes | n/a |
| `/apps/firstrunwizard/wizard` (what the patched js requests) | 302 | **200, 1585 bytes — byte-identical** |
| `/apps/firstrunwizard/wizard.php` (nothing requests this) | 500 | 500 (still a raw file) |
| `ajax/disable` end-to-end with a valid CSRF token | 200, clears `show` pref | 200, clears `show` pref |

So the value here is that a route is reachable at the url it declares, and the
bug class cannot resurface if a caller is ever written the obvious way.

## What this changes

* The route urls lose their `.php` suffix so that they no longer resolve to files
  on disk. The `actionInclude()` targets and the **route names** are unchanged, so
  `linkToRoute()` callers keep working.
* `js/firstrunwizard.js` moves from `OC.filePath()` to `OC.generateUrl()` for both
  the colorbox `href` (the wizard body) and the on-close disable call. Simply
  dropping the `.php` from the `OC.filePath()` calls would not work: with a
  non-`.php` file name and a non-core app, `OC.filePath()` falls through to its
  `OC.appswebroots[app]` branch and yields *static* urls rather than routed ones.

No backwards-compatible `.php` alias is added — an alias would re-introduce
exactly the shadowed url this change removes, so it would be dead on arrival.

`ajax/enable.php` (route `firstrunwizard_enable`) has no js caller in this repo;
its url is rewired for consistency and so the route is reachable at all.

## Release note

This app needs its own release before an ownCloud bundle picks the change up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
